### PR TITLE
update library user table

### DIFF
--- a/database/migrations/2022_05_11_144057_create_library_users_table.php
+++ b/database/migrations/2022_05_11_144057_create_library_users_table.php
@@ -17,7 +17,6 @@ class CreateLibraryUsersTable extends Migration
             $table->id();
             $table->string('u_name');
             $table->string('u_email')->unique();
-            $table->string('password');
             $table->string('u_type');
             $table->timestamp('is_suspended')->nullable();
             $table->timestamps();


### PR DESCRIPTION
delete password field because borrowers no need to log in to the system library admin handle all the actions